### PR TITLE
Updated README and fixed inaccurate examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Output of `botsay 'Build complete'`:
     |_| |_|
 ```
 
-Output of `botsay -- $(fortune)`:
+Output of `fortune | botsay`:
 
 ```
        Y__           .--------------------------------------------.
@@ -28,7 +28,7 @@ Output of `botsay -- $(fortune)`:
      __) (__
 ```
 
-Output of `botsay -- $(botsay;botsay;botsay)`:
+Output of `botsay -- $(botsay -o;botsay -o;botsay -o)`:
 
 ```
      _._._          .--------------------------------------------.
@@ -40,7 +40,7 @@ Output of `botsay -- $(botsay;botsay;botsay)`:
     [_| |_]         '--------------------------------------------'
 ```
 
-Output of `date --iso-8601 | botsay -`:
+Output of `date --iso-8601 | botsay`:
 
 ```
       .---.          .-------------.
@@ -67,6 +67,9 @@ With Go 1.17 or later:
 ### Flags
 
 * `-c` - color the output with rainbow-like colors
+* `-o` - only output robot, suppress message
+* `-i` - specify a custom bot ID to use for generating the ASCII art.
+* `-p` - print the bot's ID after generating the ASCII art.
 * `--version` - output the current version
 * `--help` - output brief help
 


### PR DESCRIPTION
I noticed that -p and -i were also missing from README, so I added them too.

Hope this is helpful